### PR TITLE
Scan image with latest tag per default

### DIFF
--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,6 +1,6 @@
 module-name: snatch
 protecode:
-  - europe-docker.pkg.dev/kyma-project/prod/snatch:v20250107-7f1e539e
+  - europe-docker.pkg.dev/kyma-project/prod/snatch:latest
 whitesource:
   language: golang-mod
   subprojects: false


### PR DESCRIPTION
**Description**

Adjusting sec-config to scan always the latest container image per default.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
